### PR TITLE
Add anti-kt energy loss column

### DIFF
--- a/EvaluateEnergyLoss.cpp
+++ b/EvaluateEnergyLoss.cpp
@@ -118,7 +118,7 @@ void RunAnalysis(vector<PseudoJet> &V, ofstream &out, double Weight)
 
       out << Weight << " " << Jet.perp() << " " << Jet.eta() << " " << Jet.phi() << " " << Constituents.size();
 
-      double PValues[] = {0.0, 0.5, 1.0};
+      double PValues[] = {0.0, 0.5, 1.0, -1.0};
 
       for(double p : PValues)
       {

--- a/makefile
+++ b/makefile
@@ -5,9 +5,9 @@
 default: TestRun
 
 TestRun: Execute
-	wget https://cernbox.cern.ch/remote.php/dav/public-files/7ST6Uclh5VjJnt7/workshopexercise10k_1.hepmc
+	wget -N https://cernbox.cern.ch/remote.php/dav/public-files/7ST6Uclh5VjJnt7/workshopexercise10k_1.hepmc
 	./Execute --Input workshopexercise10k_1.hepmc --Output test.out
-	# cat test.out | TextToTree test.root 6 "JetPT:JetEta:JetPhi:CAELoss:TimeELoss:KTELoss"
+	# cat test.out | TextToTree test.root 9 "Weight:JetPT:JetEta:JetPhi:NConst:CAELoss:TimeELoss:KTELoss:AKTELoss"
 
 Execute: EvaluateEnergyLoss.cpp CATree.o TauHelperFunctions3.o
 	g++ EvaluateEnergyLoss.cpp -o Execute TauHelperFunctions3.o CATree.o -std=c++17 \


### PR DESCRIPTION
Hi Yi, 

Quick add of a column for anti-kt energy loss. The distribution with anti-kt is different from others, so it may be a good idea to look at it for testing/R_AA calculation.

![energyloss_antikt](https://github.com/user-attachments/assets/86cb30b0-28a1-4635-8fdd-fb6f52d6e754)

(For the initial lin(0.5-0.15) medium, pT > 100 GeV, weighted entries, normalized)



Also minor change in makefile to avoid re-downloading files.